### PR TITLE
doc(readme): Fixed run commad for cuda example and added information about LD_LIBRARY_PATH variable

### DIFF
--- a/english/cuda/nostress/README.md
+++ b/english/cuda/nostress/README.md
@@ -123,9 +123,11 @@ You need to have CUDA and the Nvidia driver installed!
 Then just run the **Go** code with the command:
 
 ```
-go run maxmul.go
+LD_LIBRARY_PATH=${PWD}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}} go run maxmul.go
 ...
 [19 36 16 27 41 31 28 15 24]
 ```
+
+You have to add `LD_LIBRARY_PATH=${PWD}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}` when putting library into location other than already defined in `LD_LIBRARY_PATH`. You might find more information about this environment variable [here](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#post-installation-actions) 
 
 And this is the result of matrix multiplication!

--- a/portuguese/cuda/nostress/README.md
+++ b/portuguese/cuda/nostress/README.md
@@ -123,9 +123,11 @@ Você precisa ter o CUDA e o driver Nvidia instalados!
 Depois, é só rodar o código **Go** com o comando: 
 
 ```
-go run maxmul.go
+LD_LIBRARY_PATH=${PWD}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}} go run maxmul.go
 ...
 [19 36 16 27 41 31 28 15 24]
 ```
+
+Você deve adicionar `LD_LIBRARY_PATH = $ {PWD} $ {LD_LIBRARY_PATH: +: $ {LD_LIBRARY_PATH}}` ao colocar a biblioteca em um local diferente do já definido em `LD_LIBRARY_PATH`. Você pode encontrar mais informações sobre esta variável de ambiente [aqui] (https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#post-installation-actions)
 
 E este é o resultado da multiplicação das matrizes!


### PR DESCRIPTION
Fixed go run command in CUDA example for English and Portuguese versions, added more information about `LD_LIBRARY_PATH`.

See: https://github.com/cleuton/golang-network/issues/2